### PR TITLE
Update JSON-LD Related Deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -821,79 +821,6 @@
         "file-uri-to-path": "1.0.0"
       }
     },
-    "bitcore-lib": {
-      "version": "0.13.19",
-      "resolved": "https://registry.npmjs.org/bitcore-lib/-/bitcore-lib-0.13.19.tgz",
-      "integrity": "sha1-SK8em9oQBnwasWJjRyta3SAA89w=",
-      "requires": {
-        "bn.js": "=2.0.4",
-        "bs58": "=2.0.0",
-        "buffer-compare": "=1.0.0",
-        "elliptic": "=3.0.3",
-        "inherits": "=2.0.1",
-        "lodash": "=3.10.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.4.tgz",
-          "integrity": "sha1-Igp81nf38b+pNif/QZN3b+eBlIA="
-        },
-        "bs58": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.0.tgz",
-          "integrity": "sha1-crcTvtIjoKxRi72g484/SBfznrU="
-        },
-        "buffer-compare": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-compare/-/buffer-compare-1.0.0.tgz",
-          "integrity": "sha1-rKp6lm6Y7un64Usxw5pfFY+zxKI="
-        },
-        "elliptic": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
-          "integrity": "sha1-hlybQgv75VAGuflp+XoNLESWZZU=",
-          "requires": {
-            "bn.js": "^2.0.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "inherits": "^2.0.1"
-          },
-          "dependencies": {
-            "brorand": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
-              "integrity": "sha1-B7VMowKGq9Fxig4qgwgD79yb+gQ="
-            },
-            "hash.js": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
-              "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
-              "requires": {
-                "inherits": "^2.0.1"
-              }
-            }
-          }
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        }
-      }
-    },
-    "bitcore-message": {
-      "version": "github:CoMakery/bitcore-message#8799cc327029c3d34fc725f05b2cf981363f6ebf",
-      "from": "github:CoMakery/bitcore-message#dist",
-      "requires": {
-        "bitcore-lib": "^0.13.7"
-      }
-    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -3450,44 +3377,29 @@
       }
     },
     "jsonld": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-1.8.0.tgz",
-      "integrity": "sha512-a3bwbR0wqFstxKsGoimUIIKBdfJ+yb9kWK+WK7MpVyvfYtITMpUtF3sNoN1wG/W+jGDgya0ACRh++jtTozxtyQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-2.0.2.tgz",
+      "integrity": "sha512-/TQzRe75/3h2khu57IUojha5oat+M82bm8RYw0jLhlmmPrW/kTWAZ9nGzKPfZWnPYnVVJJMQVc/pU8HCmpv9xg==",
       "requires": {
         "canonicalize": "^1.0.1",
+        "lru-cache": "^5.1.1",
         "rdf-canonize": "^1.0.2",
         "request": "^2.88.0",
-        "semver": "^5.6.0",
+        "semver": "^6.3.0",
         "xmldom": "0.1.19"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
       }
     },
     "jsonld-signatures": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-4.4.0.tgz",
-      "integrity": "sha512-QupObkSSYUau6F2e4Rt7ytOBhNSnLLpRoEsltAF+QE6iar7V+G581czdMeJ+xCYDK36gl/EBeTlXaZyq/4CycQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-5.1.0.tgz",
+      "integrity": "sha512-cI/iZbbU0ndH74L1AmSziSh59QxigPQLVbC7Xdy0TCxzisBfXScB/TjGOR6r/qZ0cFeXldBKiCHaDjB8825WPw==",
       "requires": {
         "base64url": "^3.0.1",
-        "bitcore-message": "github:CoMakery/bitcore-message#dist",
-        "bs58": "^4.0.1",
         "crypto-ld": "^3.7.0",
-        "jsonld": "^1.6.2",
-        "node-forge": "^0.8.3",
+        "jsonld": "^2.0.2",
+        "node-forge": "^0.9.1",
         "security-context": "^4.0.0",
-        "serialize-error": "^4.1.0"
-      },
-      "dependencies": {
-        "node-forge": {
-          "version": "0.8.5",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
-          "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q=="
-        }
+        "serialize-error": "^5.0.0"
       }
     },
     "jsprim": {
@@ -3600,7 +3512,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "requires": {
         "yallist": "^3.0.2"
       }
@@ -3826,8 +3737,7 @@
     "node-forge": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
-      "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==",
-      "dev": true
+      "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
     },
     "node-gyp-build": {
       "version": "4.2.0",
@@ -4214,24 +4124,12 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "rdf-canonize": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-1.0.3.tgz",
-      "integrity": "sha512-piLMOB5Q6LJSVx2XzmdpHktYVb8TmVTy8coXJBFtdkcMC96DknZOuzpAYqCWx2ERZX7xEW+mMi8/wDuMJS/95w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-1.1.0.tgz",
+      "integrity": "sha512-DV06OnhVfl2zcZJQCt+YvU+hoZVgpyQpNFLeAmghq8RJybUxD3B4LRzlBquYS5k+LLd8/c3g5Gnhkqjw5qRMvg==",
       "requires": {
-        "node-forge": "^0.8.1",
-        "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "node-forge": {
-          "version": "0.8.5",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
-          "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q=="
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
+        "node-forge": "^0.9.1",
+        "semver": "^6.3.0"
       }
     },
     "react-is": {
@@ -4470,11 +4368,11 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "serialize-error": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-4.1.0.tgz",
-      "integrity": "sha512-5j9GgyGsP9vV9Uj1S0lDCvlsd+gc2LEPVK7HHHte7IyPwOD4lVQFeaX143gx3U5AnoCi+wbcb3mvaxVysjpxEw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
+      "integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
       "requires": {
-        "type-fest": "^0.3.0"
+        "type-fest": "^0.8.0"
       }
     },
     "set-blocking": {
@@ -5026,9 +4924,9 @@
       }
     },
     "type-fest": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "uc.micro": {
       "version": "1.0.6",
@@ -5146,18 +5044,18 @@
       }
     },
     "vc-js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/vc-js/-/vc-js-0.3.0.tgz",
-      "integrity": "sha512-XRbg7pcW2bucOECtua3Ox2el/0OhMSEOVsd0MpZTjge4xBmMwEk1mZqsDjCSLk8Lysa0DYg5MN3doJnZ57fhww==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/vc-js/-/vc-js-0.6.4.tgz",
+      "integrity": "sha512-ogwYys94k8mFyFZEn1Ru3nIA5Z/9C4iCU4grNWUYOYVWldcsn6UDp6erYFbaSkilzv7RK3cQu5N8prkxfHpZwA==",
       "dev": true,
       "requires": {
         "commander": "^2.20.3",
-        "credentials-context": "1.0.0",
+        "credentials-context": "^1.0.0",
         "debug": "^4.1.1",
         "fs-extra": "^8.1.0",
         "get-stdin": "^7.0.0",
         "jsonld": "^2.0.2",
-        "jsonld-signatures": "^4.6.0",
+        "jsonld-signatures": "^5.0.0",
         "supports-color": "^7.1.0"
       },
       "dependencies": {
@@ -5175,36 +5073,6 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
-        },
-        "jsonld": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-2.0.2.tgz",
-          "integrity": "sha512-/TQzRe75/3h2khu57IUojha5oat+M82bm8RYw0jLhlmmPrW/kTWAZ9nGzKPfZWnPYnVVJJMQVc/pU8HCmpv9xg==",
-          "dev": true,
-          "requires": {
-            "canonicalize": "^1.0.1",
-            "lru-cache": "^5.1.1",
-            "rdf-canonize": "^1.0.2",
-            "request": "^2.88.0",
-            "semver": "^6.3.0",
-            "xmldom": "0.1.19"
-          }
-        },
-        "jsonld-signatures": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-4.6.0.tgz",
-          "integrity": "sha512-DerdxAFumi/ef73yiejQE8P1aVD6SLrZ8+fB6yI4OuMdOIYPhWnX+qs3ur5i8It424YoAqgx1/8MIBUTkFPJUw==",
-          "dev": true,
-          "requires": {
-            "base64url": "^3.0.1",
-            "bitcore-message": "github:CoMakery/bitcore-message#dist",
-            "bs58": "^4.0.1",
-            "crypto-ld": "^3.7.0",
-            "jsonld": "^2.0.2",
-            "node-forge": "^0.9.1",
-            "security-context": "^4.0.0",
-            "serialize-error": "^4.1.0"
-          }
         },
         "ms": {
           "version": "2.1.2",
@@ -5383,8 +5251,7 @@
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
       "version": "13.3.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "crypto-ld": "^3.7.0",
     "did-method-key": "^0.2.0",
     "jose": "^1.17.1",
-    "jsonld": "^1.8.0",
-    "jsonld-signatures": "^4.4.0"
+    "jsonld": "^2.0.0",
+    "jsonld-signatures": "^5.0.0"
   },
   "devDependencies": {
     "@trust/keyto": "^0.3.7",
@@ -34,6 +34,6 @@
     "jest": "^24.9.0",
     "jsdoc": "^3.6.3",
     "node-forge": "^0.9.1",
-    "vc-js": "^0.3.0"
+    "vc-js": "^0.6.4"
   }
 }

--- a/src/__tests__/vc-edu.spec.js
+++ b/src/__tests__/vc-edu.spec.js
@@ -59,7 +59,7 @@ describe("credential integration tests", () => {
       });
 
       expect(signedVC.proof).toBeDefined();
-      const result = await vc.verify({
+      const result = await vc.verifyCredential({
         credential: signedVC,
         compactProof: false,
         documentLoader: documentLoader,
@@ -76,9 +76,9 @@ describe("credential integration tests", () => {
       compactProof: false,
       suite: suiteDeprecated
     });
-    
+
     expect(signedVC.proof).toBeDefined();
-    const result = await vc.verify({
+    const result = await vc.verifyCredential({
       credential: signedVC,
       compactProof: false,
       documentLoader: documentLoader,

--- a/src/__tests__/vc-js-integration.spec.js
+++ b/src/__tests__/vc-js-integration.spec.js
@@ -106,7 +106,7 @@ describe("integration tests", () => {
       });
       expect(signedVC.proof).toBeDefined();
 
-      const result = await vc.verify({
+      const result = await vc.verifyCredential({
         credential: signedVC,
         compactProof: false,
         documentLoader: documentLoader,
@@ -125,7 +125,7 @@ describe("integration tests", () => {
     });
     expect(signedVC.proof).toBeDefined();
 
-    const result = await vc.verify({
+    const result = await vc.verifyCredential({
       credential: signedVC,
       compactProof: false,
       documentLoader: documentLoader,


### PR DESCRIPTION
## Ultimate Problem
`jsonld-signatures@5.x.x` cut the size of the library in half, but users who want that gain cannot use this library

## Solution
- Bump `jsonld-signatures` to the 5.x.x line
- Bump `jsonld` to the 2.x.x line
  - It is currently on the 3.x.x line but `jsonld-signatures` isn't updated to that yet
- Bump `vc-js` to the 0.6.x line
  - Fixed the breaking changes that were introduced