### PR TITLE
Update JSON-LD Related Deps

### DIFF
--- a/packages/lds-jws2020/package-lock.json
+++ b/packages/lds-jws2020/package-lock.json
@@ -821,79 +821,6 @@
         "file-uri-to-path": "1.0.0"
       }
     },
-    "bitcore-lib": {
-      "version": "0.13.19",
-      "resolved": "https://registry.npmjs.org/bitcore-lib/-/bitcore-lib-0.13.19.tgz",
-      "integrity": "sha1-SK8em9oQBnwasWJjRyta3SAA89w=",
-      "requires": {
-        "bn.js": "=2.0.4",
-        "bs58": "=2.0.0",
-        "buffer-compare": "=1.0.0",
-        "elliptic": "=3.0.3",
-        "inherits": "=2.0.1",
-        "lodash": "=3.10.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.4.tgz",
-          "integrity": "sha1-Igp81nf38b+pNif/QZN3b+eBlIA="
-        },
-        "bs58": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.0.tgz",
-          "integrity": "sha1-crcTvtIjoKxRi72g484/SBfznrU="
-        },
-        "buffer-compare": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-compare/-/buffer-compare-1.0.0.tgz",
-          "integrity": "sha1-rKp6lm6Y7un64Usxw5pfFY+zxKI="
-        },
-        "elliptic": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
-          "integrity": "sha1-hlybQgv75VAGuflp+XoNLESWZZU=",
-          "requires": {
-            "bn.js": "^2.0.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "inherits": "^2.0.1"
-          },
-          "dependencies": {
-            "brorand": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
-              "integrity": "sha1-B7VMowKGq9Fxig4qgwgD79yb+gQ="
-            },
-            "hash.js": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
-              "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
-              "requires": {
-                "inherits": "^2.0.1"
-              }
-            }
-          }
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        }
-      }
-    },
-    "bitcore-message": {
-      "version": "github:CoMakery/bitcore-message#8799cc327029c3d34fc725f05b2cf981363f6ebf",
-      "from": "github:CoMakery/bitcore-message#dist",
-      "requires": {
-        "bitcore-lib": "^0.13.7"
-      }
-    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -3450,44 +3377,29 @@
       }
     },
     "jsonld": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-1.8.0.tgz",
-      "integrity": "sha512-a3bwbR0wqFstxKsGoimUIIKBdfJ+yb9kWK+WK7MpVyvfYtITMpUtF3sNoN1wG/W+jGDgya0ACRh++jtTozxtyQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-2.0.2.tgz",
+      "integrity": "sha512-/TQzRe75/3h2khu57IUojha5oat+M82bm8RYw0jLhlmmPrW/kTWAZ9nGzKPfZWnPYnVVJJMQVc/pU8HCmpv9xg==",
       "requires": {
         "canonicalize": "^1.0.1",
+        "lru-cache": "^5.1.1",
         "rdf-canonize": "^1.0.2",
         "request": "^2.88.0",
-        "semver": "^5.6.0",
+        "semver": "^6.3.0",
         "xmldom": "0.1.19"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
       }
     },
     "jsonld-signatures": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-4.4.0.tgz",
-      "integrity": "sha512-QupObkSSYUau6F2e4Rt7ytOBhNSnLLpRoEsltAF+QE6iar7V+G581czdMeJ+xCYDK36gl/EBeTlXaZyq/4CycQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-5.1.0.tgz",
+      "integrity": "sha512-cI/iZbbU0ndH74L1AmSziSh59QxigPQLVbC7Xdy0TCxzisBfXScB/TjGOR6r/qZ0cFeXldBKiCHaDjB8825WPw==",
       "requires": {
         "base64url": "^3.0.1",
-        "bitcore-message": "github:CoMakery/bitcore-message#dist",
-        "bs58": "^4.0.1",
         "crypto-ld": "^3.7.0",
-        "jsonld": "^1.6.2",
-        "node-forge": "^0.8.3",
+        "jsonld": "^2.0.2",
+        "node-forge": "^0.9.1",
         "security-context": "^4.0.0",
-        "serialize-error": "^4.1.0"
-      },
-      "dependencies": {
-        "node-forge": {
-          "version": "0.8.5",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
-          "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q=="
-        }
+        "serialize-error": "^5.0.0"
       }
     },
     "jsprim": {
@@ -3600,7 +3512,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "requires": {
         "yallist": "^3.0.2"
       }
@@ -3826,8 +3737,7 @@
     "node-forge": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
-      "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==",
-      "dev": true
+      "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
     },
     "node-gyp-build": {
       "version": "4.2.0",
@@ -4214,24 +4124,12 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "rdf-canonize": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-1.0.3.tgz",
-      "integrity": "sha512-piLMOB5Q6LJSVx2XzmdpHktYVb8TmVTy8coXJBFtdkcMC96DknZOuzpAYqCWx2ERZX7xEW+mMi8/wDuMJS/95w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-1.1.0.tgz",
+      "integrity": "sha512-DV06OnhVfl2zcZJQCt+YvU+hoZVgpyQpNFLeAmghq8RJybUxD3B4LRzlBquYS5k+LLd8/c3g5Gnhkqjw5qRMvg==",
       "requires": {
-        "node-forge": "^0.8.1",
-        "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "node-forge": {
-          "version": "0.8.5",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
-          "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q=="
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
+        "node-forge": "^0.9.1",
+        "semver": "^6.3.0"
       }
     },
     "react-is": {
@@ -4470,11 +4368,11 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "serialize-error": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-4.1.0.tgz",
-      "integrity": "sha512-5j9GgyGsP9vV9Uj1S0lDCvlsd+gc2LEPVK7HHHte7IyPwOD4lVQFeaX143gx3U5AnoCi+wbcb3mvaxVysjpxEw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
+      "integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
       "requires": {
-        "type-fest": "^0.3.0"
+        "type-fest": "^0.8.0"
       }
     },
     "set-blocking": {
@@ -5026,9 +4924,9 @@
       }
     },
     "type-fest": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "uc.micro": {
       "version": "1.0.6",
@@ -5146,18 +5044,18 @@
       }
     },
     "vc-js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/vc-js/-/vc-js-0.3.0.tgz",
-      "integrity": "sha512-XRbg7pcW2bucOECtua3Ox2el/0OhMSEOVsd0MpZTjge4xBmMwEk1mZqsDjCSLk8Lysa0DYg5MN3doJnZ57fhww==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/vc-js/-/vc-js-0.6.4.tgz",
+      "integrity": "sha512-ogwYys94k8mFyFZEn1Ru3nIA5Z/9C4iCU4grNWUYOYVWldcsn6UDp6erYFbaSkilzv7RK3cQu5N8prkxfHpZwA==",
       "dev": true,
       "requires": {
         "commander": "^2.20.3",
-        "credentials-context": "1.0.0",
+        "credentials-context": "^1.0.0",
         "debug": "^4.1.1",
         "fs-extra": "^8.1.0",
         "get-stdin": "^7.0.0",
         "jsonld": "^2.0.2",
-        "jsonld-signatures": "^4.6.0",
+        "jsonld-signatures": "^5.0.0",
         "supports-color": "^7.1.0"
       },
       "dependencies": {
@@ -5175,36 +5073,6 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
-        },
-        "jsonld": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-2.0.2.tgz",
-          "integrity": "sha512-/TQzRe75/3h2khu57IUojha5oat+M82bm8RYw0jLhlmmPrW/kTWAZ9nGzKPfZWnPYnVVJJMQVc/pU8HCmpv9xg==",
-          "dev": true,
-          "requires": {
-            "canonicalize": "^1.0.1",
-            "lru-cache": "^5.1.1",
-            "rdf-canonize": "^1.0.2",
-            "request": "^2.88.0",
-            "semver": "^6.3.0",
-            "xmldom": "0.1.19"
-          }
-        },
-        "jsonld-signatures": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-4.6.0.tgz",
-          "integrity": "sha512-DerdxAFumi/ef73yiejQE8P1aVD6SLrZ8+fB6yI4OuMdOIYPhWnX+qs3ur5i8It424YoAqgx1/8MIBUTkFPJUw==",
-          "dev": true,
-          "requires": {
-            "base64url": "^3.0.1",
-            "bitcore-message": "github:CoMakery/bitcore-message#dist",
-            "bs58": "^4.0.1",
-            "crypto-ld": "^3.7.0",
-            "jsonld": "^2.0.2",
-            "node-forge": "^0.9.1",
-            "security-context": "^4.0.0",
-            "serialize-error": "^4.1.0"
-          }
         },
         "ms": {
           "version": "2.1.2",
@@ -5383,8 +5251,7 @@
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
       "version": "13.3.0",

--- a/packages/lds-jws2020/package.json
+++ b/packages/lds-jws2020/package.json
@@ -23,8 +23,8 @@
     "crypto-ld": "^3.7.0",
     "did-method-key": "^0.2.0",
     "jose": "^1.17.1",
-    "jsonld": "^1.8.0",
-    "jsonld-signatures": "^4.4.0"
+    "jsonld": "^2.0.0",
+    "jsonld-signatures": "^5.0.0"
   },
   "devDependencies": {
     "@trust/keyto": "^0.3.7",
@@ -33,6 +33,6 @@
     "jest": "^24.9.0",
     "jsdoc": "^3.6.3",
     "node-forge": "^0.9.1",
-    "vc-js": "^0.3.0"
+    "vc-js": "^0.6.4"
   }
 }

--- a/packages/lds-jws2020/src/JsonWebKeyLinkedDataKeyClass2020.js
+++ b/packages/lds-jws2020/src/JsonWebKeyLinkedDataKeyClass2020.js
@@ -1,0 +1,290 @@
+const jose = require("jose");
+const base64url = require("base64url");
+
+const getRecomendedAlg = require("./getRecomendedAlg");
+
+class JsonWebKeyLinkedDataKeyClass2020 {
+  /**
+   * @param {KeyPairOptions} options - The options to use.
+   * @param {string} options.id - The key ID.
+   * @param {string} options.controller - The key controller.
+   * @param {string} options.publicKeyJwk - The JWK encoded Public Key.
+   * @param {string} options.privateKeyJwk - The JWK Private Key.
+   * @param {string} options.alg - The JWS alg for this key.
+   */
+  constructor(options = {}) {
+    this.id = options.id;
+    this.type = options.type;
+    this.controller = options.controller;
+    this.privateKeyJwk = options.privateKeyJwk;
+    this.publicKeyJwk = options.publicKeyJwk;
+
+    if (options.alg) {
+      throw new Error(
+        "alg is no longer allowed. See the mapping table here: https://github.com/w3c-ccg/lds-jws2020"
+      );
+    }
+
+    if (this.publicKeyJwk === undefined) {
+      this.publicKeyJwk = jose.JWK.asKey(this.privateKeyJwk).toJWK(false);
+    }
+
+    if (this.alg === undefined) {
+      this.alg = getRecomendedAlg(this.publicKeyJwk);
+    }
+
+    if (this.id === undefined) {
+      this.id = this.controller + "#" + this.fingerprint();
+    }
+  }
+
+  /**
+   * Returns the JWK encoded public key.
+   *
+   * @returns {string} The JWK encoded public key.
+   */
+  get publicKey() {
+    return this.publicKeyJwk;
+  }
+
+  /**
+   * Returns the JWK encoded private key.
+   *
+   * @returns {string} The JWK encoded private key.
+   */
+  get privateKey() {
+    return this.privateKeyJwk;
+  }
+
+  /**
+   * Generates a KeyPair with an optional deterministic seed.
+   * @param {KeyPairOptions} [options={}] - The options to use.
+   *
+   * @returns {Promise<JsonWebKeyLinkedDataKeyClass2020>} Generates a key pair.
+   */
+  static async generate(kty, crv, options = {}) {
+    let key = jose.JWK.generateSync(kty, crv);
+    return new JsonWebKeyLinkedDataKeyClass2020({
+      privateKeyJwk: key.toJWK(true),
+      publicKeyJwk: key.toJWK(),
+      ...options
+    });
+  }
+
+  /**
+   * Returns a signer object for use with jsonld-signatures.
+   *
+   * @returns {{sign: Function}} A signer for the json-ld block.
+   */
+  signer() {
+    return joseSignerFactory(this);
+  }
+
+  /**
+   * Returns a verifier object for use with jsonld-signatures.
+   *
+   * @returns {{verify: Function}} Used to verify jsonld-signatures.
+   */
+  verifier() {
+    return joseVerifierFactory(this);
+  }
+
+  /**
+   * Adds a public key base to a public key node.
+   *
+   * @param {Object} publicKeyNode - The public key node in a jsonld-signature.
+   * @param {string} publicKeyNode.publicKeyJwk - JWK Public Key for
+   *   jsonld-signatures.
+   *
+   * @returns {Object} A PublicKeyNode in a block.
+   */
+  addEncodedPublicKey(publicKeyNode) {
+    publicKeyNode.publicKeyJwk = this.publicKeyJwk;
+    return publicKeyNode;
+  }
+
+  /**
+   * Generates and returns a public key fingerprint using https://tools.ietf.org/html/rfc7638
+   *
+   * @param {string} publicKeyJwk - The jwk encoded public key material.
+   *
+   * @returns {string} The fingerprint.
+   */
+  static fingerprintFromPublicKey({ publicKeyJwk }) {
+    const temp = { ...publicKeyJwk };
+    delete temp.kid;
+    const k = jose.JWK.asKey(temp);
+    return k.kid;
+  }
+
+  /**
+   * Generates and returns a public key fingerprint using https://tools.ietf.org/html/rfc7638
+   *
+   * @returns {string} The fingerprint.
+   */
+  fingerprint() {
+    const temp = { ...this.publicKeyJwk };
+    delete temp.kid;
+    const k = jose.JWK.asKey(temp);
+    return k.kid;
+  }
+
+  /**
+   * Tests whether the fingerprint was generated from a given key pair.
+   *
+   * @param {string} fingerprint - A JWK public key.
+   *
+   * @returns {Object} An object indicating valid is true or false.
+   */
+  verifyFingerprint(/*fingerprint*/) {
+    // TODO: implement
+    throw new Error("`verifyFingerprint` API is not implemented.");
+  }
+
+  static async from(options) {
+    return new JsonWebKeyLinkedDataKeyClass2020(options);
+  }
+
+  /**
+   * Contains the public key for the KeyPair
+   * and other information that json-ld Signatures can use to form a proof.
+   * @param {Object} [options={}] - Needs either a controller or owner.
+   * @param {string} [options.controller=this.controller]  - DID of the
+   * person/entity controlling this key pair.
+   *
+   * @returns {Object} A public node with
+   * information used in verification methods by signatures.
+   */
+  publicNode({ controller = this.controller } = {}) {
+    const publicNode = {
+      id: this.id,
+      type: this.type
+    };
+    if (controller) {
+      publicNode.controller = controller;
+    }
+    this.addEncodedPublicKey(publicNode); // Subclass-specific
+    return publicNode;
+  }
+}
+
+/**
+ * @ignore
+ * Returns an object with an async sign function.
+ * The sign function is bound to the KeyPair
+ * and then returned by the KeyPair's signer method.
+ * @param {JsonWebKeyLinkedDataKeyClass2020} key - An JsonWebKeyLinkedDataKeyClass2020.
+ *
+ * @returns {{sign: Function}} An object with an async function sign
+ * using the private key passed in.
+ */
+function joseSignerFactory(key) {
+  if (!key.privateKeyJwk) {
+    return {
+      async sign() {
+        throw new Error("No private key to sign with.");
+      }
+    };
+  }
+
+  return {
+    async sign({ data }) {
+      const header = {
+        alg: this.alg,
+        b64: false,
+        crit: ["b64"]
+      };
+      toBeSigned = Buffer.from(data.buffer, data.byteOffset, data.length);
+      const flattened = jose.JWS.sign.flattened(
+        toBeSigned,
+        jose.JWK.asKey(key.privateKeyJwk),
+        header
+      );
+      return flattened.protected + ".." + flattened.signature;
+    }
+  };
+}
+
+/**
+ * @ignore
+ * Returns an object with an async verify function.
+ * The verify function is bound to the KeyPair
+ * and then returned by the KeyPair's verifier method.
+ * @param {JsonWebKeyLinkedDataKeyClass2020} key - An JsonWebKeyLinkedDataKeyClass2020.
+ *
+ * @returns {{verify: Function}} An async verifier specific
+ * to the key passed in.
+ */
+joseVerifierFactory = key => {
+  if (!key.publicKeyJwk) {
+    return {
+      async sign() {
+        throw new Error("No public key to verify with.");
+      }
+    };
+  }
+
+  return {
+    async verify({ data, signature }) {
+      const alg = key.alg; // Ex: "EdDSA";
+      const type = key.type; //Ex: "Ed25519Signature2018";
+      const [encodedHeader, encodedSignature] = signature.split("..");
+      let header;
+      try {
+        header = JSON.parse(base64url.decode(encodedHeader));
+      } catch (e) {
+        throw new Error("Could not parse JWS header; " + e);
+      }
+      if (!(header && typeof header === "object")) {
+        throw new Error("Invalid JWS header.");
+      }
+
+      if (header.alg !== alg) {
+        throw new Error(
+          `Invalid JWS header, expected ${header.alg} === ${alg}.`
+        );
+      }
+
+      // confirm header matches all expectations
+      if (
+        !(
+          header.alg === alg &&
+          header.b64 === false &&
+          Array.isArray(header.crit) &&
+          header.crit.length === 1 &&
+          header.crit[0] === "b64"
+        ) &&
+        Object.keys(header).length === 3
+      ) {
+        throw new Error(
+          `Invalid JWS header parameters ${JSON.stringify(header)} for ${type}.`
+        );
+      }
+
+      let verified = false;
+
+      const detached = {
+        protected: encodedHeader,
+        signature: encodedSignature
+      };
+
+      const payload = Buffer.from(data.buffer, data.byteOffset, data.length);
+
+      try {
+        jose.JWS.verify(
+          { ...detached, payload },
+          jose.JWK.asKey(key.publicKeyJwk),
+          {
+            crit: ["b64"]
+          }
+        );
+        verified = true;
+      } catch (e) {
+        console.error("An error occurred when verifying signature: ", e);
+      }
+      return verified;
+    }
+  };
+};
+
+module.exports = JsonWebKeyLinkedDataKeyClass2020;

--- a/packages/lds-jws2020/src/JsonWebSignature2020.js
+++ b/packages/lds-jws2020/src/JsonWebSignature2020.js
@@ -1,6 +1,7 @@
 const {
   suites: { LinkedDataSignature }
 } = require("jsonld-signatures");
+const jsonld = require("jsonld");
 
 const base64url = require("base64url");
 

--- a/packages/lds-jws2020/src/JsonWebSignature2020.js
+++ b/packages/lds-jws2020/src/JsonWebSignature2020.js
@@ -1,0 +1,165 @@
+const {
+  suites: { LinkedDataSignature }
+} = require("jsonld-signatures");
+
+const base64url = require("base64url");
+
+const getRecomendedAlg = require("./getRecomendedAlg");
+
+class JsonWebSignature2020 extends LinkedDataSignature {
+  static inferAlg(lds) {
+    const { alg } = JSON.parse(base64url.decode(lds.proof.jws.split("..")[0]));
+    return alg;
+  }
+  /**
+   * @param linkedDataSigantureType {string} The name of the signature suite.
+   * @param linkedDataSignatureVerificationKeyType {string} The name verification key type for the signature suite.
+   *
+   * @param alg {string} JWS alg provided by subclass.
+   * @param [LDKeyClass] {LDKeyClass} provided by subclass or subclass
+   *   overrides `getVerificationMethod`.
+   *
+   *
+   * This parameter is required for signing:
+   *
+   * @param [signer] {function} an optional signer.
+   *
+   * @param [proofSignatureKey] {string} the property in the proof that will contain the signature.
+   * @param [date] {string|Date} signing date to use if not passed.
+   * @param [key] {LDKeyPair} an optional crypto-ld KeyPair.
+   * @param [useNativeCanonize] {boolean} true to use a native canonize
+   *   algorithm.
+   */
+  constructor({
+    linkedDataSigantureType,
+    linkedDataSignatureVerificationKeyType,
+    alg,
+    LDKeyClass,
+    signer,
+    key,
+    proofSignatureKey,
+    date,
+    useNativeCanonize
+  } = {}) {
+    super({
+      type: linkedDataSigantureType,
+      LDKeyClass,
+      alg,
+      date,
+      useNativeCanonize
+    });
+    this.alg = alg;
+    this.LDKeyClass = LDKeyClass;
+    this.signer = signer;
+    this.requiredKeyType = linkedDataSignatureVerificationKeyType;
+    this.proofSignatureKey = proofSignatureKey || "jws";
+
+    if (key) {
+      const publicKey = key.publicNode();
+      this.verificationMethod = publicKey.id;
+      this.key = key;
+      if (typeof key.signer === "function") {
+        this.signer = key.signer();
+      }
+      if (typeof key.verifier === "function") {
+        this.verifier = key.verifier(key, this.alg, this.type);
+      }
+    }
+
+    if (this.alg === undefined) {
+      this.alg = getRecomendedAlg(key.publicKeyJwk);
+    }
+  }
+
+  /**
+   * @param verifyData {Uint8Array}.
+   * @param proof {object}
+   *
+   * @returns {Promise<{object}>} the proof containing the signature value.
+   */
+  async sign({ verifyData, proof }) {
+    if (!(this.signer && typeof this.signer.sign === "function")) {
+      throw new Error("A signer API has not been specified.");
+    }
+
+    proof[this.proofSignatureKey] = await this.signer.sign({
+      data: verifyData
+    });
+    return proof;
+  }
+
+  /**
+   * @param verifyData {Uint8Array}.
+   * @param verificationMethod {object}.
+   * @param document {object} the document the proof applies to.
+   * @param proof {object} the proof to be verified.
+   * @param purpose {ProofPurpose}
+   * @param documentLoader {function}
+   * @param expansionMap {function}
+   *
+   * @returns {Promise<{boolean}>} Resolves with the verification result.
+   */
+  async verifySignature({ verifyData, verificationMethod, proof }) {
+    let { verifier } = this;
+
+    if (!verifier) {
+      const key = await this.LDKeyClass.from(verificationMethod);
+      verifier = key.verifier(key, this.alg, this.type);
+    }
+    return await verifier.verify({
+      data: Buffer.from(verifyData),
+      signature: proof[this.proofSignatureKey]
+    });
+  }
+
+  async assertVerificationMethod({ verificationMethod }) {
+    if (!jsonld.hasValue(verificationMethod, "type", this.requiredKeyType)) {
+      throw new Error(
+        `Invalid key type. Key type must be "${this.requiredKeyType}".`
+      );
+    }
+  }
+
+  async getVerificationMethod({ proof, documentLoader }) {
+    if (this.key) {
+      return this.key.publicNode();
+    }
+
+    const verificationMethod = await super.getVerificationMethod({
+      proof,
+      documentLoader
+    });
+    await this.assertVerificationMethod({ verificationMethod });
+    return verificationMethod;
+  }
+
+  async matchProof({ proof, document, purpose, documentLoader, expansionMap }) {
+    if (
+      !(await super.matchProof({
+        proof,
+        document,
+        purpose,
+        documentLoader,
+        expansionMap
+      }))
+    ) {
+      return false;
+    }
+    if (!this.key) {
+      // no key specified, so assume this suite matches and it can be retrieved
+      return true;
+    }
+
+    let { verificationMethod } = proof;
+    if (!verificationMethod) {
+      verificationMethod = proof.creator;
+    }
+    // only match if the key specified matches the one in the proof
+    if (typeof verificationMethod === "object") {
+      return verificationMethod.id === this.key.id;
+    }
+    return verificationMethod === this.key.id;
+  }
+}
+
+module.exports = JsonWebSignature2020;

--- a/packages/lds-jws2020/src/getRecomendedAlg.js
+++ b/packages/lds-jws2020/src/getRecomendedAlg.js
@@ -1,0 +1,21 @@
+const mapper = {
+  "OKP Ed25519": "EdDSA",
+  "EC secp256k1": "ES256K",
+  "EC P-256": "ES256",
+  "EC P-384": "ES384",
+  "EC P-521": "ES512"
+};
+
+const getRecomendedAlg = ({ kty, crv }) => {
+  if (kty === "RSA") {
+    return "PS256";
+  }
+
+  if (mapper[`${kty} ${crv}`]) {
+    return mapper[`${kty} ${crv}`];
+  }
+
+  throw new Error("No prefferd alg found for" + kty + " " + crv);
+};
+
+module.exports = getRecomendedAlg;

--- a/packages/lds-jws2020/src/index.js
+++ b/packages/lds-jws2020/src/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  JsonWebKeyLinkedDataKeyClass2020: require("./JsonWebKeyLinkedDataKeyClass2020"),
+  JsonWebSignature2020: require("./JsonWebSignature2020")
+};


### PR DESCRIPTION
> In response to https://github.com/w3c-ccg/lds-jws2020/pull/18#issuecomment-646882847

## Ultimate Problem
`jsonld-signatures@5.x.x` cut the size of the library in half, but users who want that gain cannot use this library

## Solution
- Bump `jsonld-signatures` to the 5.x.x line
- Bump `jsonld` to the 2.x.x line
  - It is currently on the 3.x.x line but `jsonld-signatures` isn't updated to that yet
- Bump `vc-js` to the 0.6.x line
  - Fixed the breaking changes that were introduced