### PR TITLE
w3id.org security context prevents "pretty" extensions

### DIFF
--- a/packages/json-web-signature-2020/src/__fixtures__/contexts/security-v3.json
+++ b/packages/json-web-signature-2020/src/__fixtures__/contexts/security-v3.json
@@ -1,25 +1,19 @@
 {
-  "@context": [
-    {
-      "@version": 1.1,
-      "@protected": true
+  "@context": {
+    "sec": "https://w3id.org/security#",
+    "JsonWebSignature2020": {
+      "@id": "sec:JsonWebSignature2020"
     },
-    "https://w3id.org/security/v2",
-    {
-      "JsonWebSignature2020": {
-        "@id": "sec:JsonWebSignature2020"
-      },
-      "JsonWebKey2020": {
-        "@id": "sec:JsonWebKey2020"
-      },
-      "publicKeyJwk": {
-        "@id": "sec:publicKeyJwk",
-        "@type": "@json"
-      },
-      "privateKeyJwk": {
-        "@id": "sec:privateKeyJwk",
-        "@type": "@json"
-      }
+    "JsonWebKey2020": {
+      "@id": "sec:JsonWebKey2020"
+    },
+    "publicKeyJwk": {
+      "@id": "sec:publicKeyJwk",
+      "@type": "@json"
+    },
+    "privateKeyJwk": {
+      "@id": "sec:privateKeyJwk",
+      "@type": "@json"
     }
-  ]
+  }
 }

--- a/packages/json-web-signature-2020/src/__fixtures__/credential.json
+++ b/packages/json-web-signature-2020/src/__fixtures__/credential.json
@@ -1,7 +1,8 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://www.w3.org/2018/credentials/examples/v1"
+    "https://www.w3.org/2018/credentials/examples/v1",
+    "https://w3id.org/security/v3"
   ],
   "id": "http://example.gov/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/packages/json-web-signature-2020/src/__fixtures__/documentLoader.ts
+++ b/packages/json-web-signature-2020/src/__fixtures__/documentLoader.ts
@@ -18,7 +18,7 @@ const localOverrides: any = {
   // https://w3id.org/security/v2
   // they are never called !
   // leave commented out... does not exit...
-  // 'https://w3id.org/security/v3': require('./contexts/security-v3.json'),
+  'https://w3id.org/security/v3': require('./contexts/security-v3.json'),
   'https://www.w3.org/2018/credentials/v1': require('./contexts/credentials-v1.json'),
   // leave commented out... does not exit...
   // 'https://www.w3.org/2018/credentials/v2': require('./contexts/credentials-v2.json'),

--- a/packages/json-web-signature-2020/src/__tests__/vc-js-tester.ts
+++ b/packages/json-web-signature-2020/src/__tests__/vc-js-tester.ts
@@ -14,52 +14,54 @@ const credential = {
 
 export const runTests = (suite: any) => {
   let verifiableCredential: any;
-  let verifiablePresentation: any;
+  // let verifiablePresentation: any;
 
   it('issue verifiableCredential', async () => {
     verifiableCredential = await vc.issue({
       credential: { ...credential },
       suite,
+      compactProof: false,
       documentLoader,
     });
     expect(verifiableCredential.proof).toBeDefined();
+    console.log(JSON.stringify(verifiableCredential, null, 2));
   });
 
   it('verify verifiableCredential', async () => {
-    // console.log(JSON.stringify(verifiableCredential, null, 2));
     const result = await vc.verifyCredential({
       credential: verifiableCredential,
       suite,
+      compactProof: false,
       documentLoader,
     });
     expect(result.verified).toBe(true);
   });
 
-  it('createPresentation & signPresentation', async () => {
-    const id = 'ebc6f1c2';
-    const holder = 'did:ex:12345';
-    const presentation = vc.createPresentation({
-      verifiableCredential,
-      id,
-      holder,
-    });
-    expect(presentation.type).toEqual(['VerifiablePresentation']);
-    verifiablePresentation = await vc.signPresentation({
-      presentation,
-      suite,
-      challenge: '123',
-      documentLoader,
-    });
-    expect(verifiablePresentation.proof).toBeDefined();
-  });
+  // it('createPresentation & signPresentation', async () => {
+  //   const id = 'ebc6f1c2';
+  //   const holder = 'did:ex:12345';
+  //   const presentation = vc.createPresentation({
+  //     verifiableCredential,
+  //     id,
+  //     holder,
+  //   });
+  //   expect(presentation.type).toEqual(['VerifiablePresentation']);
+  //   verifiablePresentation = await vc.signPresentation({
+  //     presentation,
+  //     suite,
+  //     challenge: '123',
+  //     documentLoader,
+  //   });
+  //   expect(verifiablePresentation.proof).toBeDefined();
+  // });
 
-  it('verify verifiablePresentation', async () => {
-    const result = await vc.verify({
-      presentation: verifiablePresentation,
-      challenge: '123',
-      suite,
-      documentLoader,
-    });
-    expect(result.verified).toBe(true);
-  });
+  // it('verify verifiablePresentation', async () => {
+  //   const result = await vc.verify({
+  //     presentation: verifiablePresentation,
+  //     challenge: '123',
+  //     suite,
+  //     documentLoader,
+  //   });
+  //   expect(result.verified).toBe(true);
+  // });
 };


### PR DESCRIPTION
This PR demonstrates that "pretty" looking JSON-LD Signature Proofs for new suites are not supported with jsonld-signatures, because of the way security-context-v2 is handling things...

This signed document is generated... but is not verifiable:

```
{
      "@context": [
        "https://www.w3.org/2018/credentials/v1",
        "https://www.w3.org/2018/credentials/examples/v1",
        "https://w3id.org/security/v3"
      ],
      "id": "http://example.gov/credentials/3732",
      "type": [
        "VerifiableCredential",
        "UniversityDegreeCredential"
      ],
      "issuer": {
        "id": "did:key:z6MkpP568Jfkc1n51vdEut2EebtvhFXkod7S6LMZTVPGsZiZ"
      },
      "issuanceDate": "2020-03-10T04:24:12.164Z",
      "credentialSubject": {
        "id": "did:key:z6MkpP568Jfkc1n51vdEut2EebtvhFXkod7S6LMZTVPGsZiZ",
        "degree": {
          "type": "BachelorDegree",
          "name": "Bachelor of Science and Arts"
        }
      },
      "proof": {
        "type": "JsonWebSignature2020",
        "created": "2019-12-11T03:50:55Z",
        "verificationMethod": "did:key:z6MkpP568Jfkc1n51vdEut2EebtvhFXkod7S6LMZTVPGsZiZ#DTXI1UCGeLHx3B6GmZtMQuR8b3KDdaayEYPJN8iME6o",
        "proofPurpose": "assertionMethod",
        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..i2zKj2p9Ek_LyTmZRD--AjqbKCDo863BLR5TAcwiUBJO7XS9e-C2LrgQOS4iBz_zuLqMgYTBYPqibER3Rr0iCw"
      }
    }
```