### PR TITLE
Note larger than 2048 key length is okay

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -395,7 +395,7 @@
           </tr>
           <tr>
             <td>RSA</td>
-            <td>2048</td>
+            <td>2048+</td>
             <td>PS256</td>
             <td></td>
             <td>RSA-OAEP</td>


### PR DESCRIPTION
Change crvOrSize for RSA from 2048 to 2048+, to indicate that a key length of greater than 2048 is okay.